### PR TITLE
Implement getAllowDeepness method (+tests)

### DIFF
--- a/src/robotto.js
+++ b/src/robotto.js
@@ -81,6 +81,66 @@ robotto.parse = function(robotsFile) {
     return rulesObj;
 };
 
+robotto.getAllowDeepness = function(userAgent, urlParam, rulesObj) {
+    let agentList = Object.keys(rulesObj.userAgents);
+    let rules = rulesObj.userAgents;
+    let routes = (url.parse(urlParam).pathname + '/').split('/');
+    let permission = 0;
+
+    // Clears empty values after splitting routes
+    routes = routes.filter(Boolean);
+
+    // Checks rules for specified user agents
+    if (agentList.indexOf(userAgent) !== -1) {
+        let userAgentRules = rulesObj.userAgents[userAgent].allow;
+
+        userAgentRules.forEach((route) => {
+            let registeredSubPaths = route.split('/').filter(Boolean);
+            let i = 0;
+
+            // For each path match adds 1 to i
+            routes.some((subPath) => {
+                if (subPath === registeredSubPaths[i]) {
+                    i++;
+                } else {
+                    // If full path does not match it has no permissions
+                    i = 0;
+                    return true;
+                }
+            });
+
+            // If it's the deepest match until now replaces permission
+            if (i > permission) {
+                permission = i;
+            }
+        });
+    }
+
+    // Checks generic rules
+    if (agentList.indexOf('*') !== -1) {
+        let userAgentRules = rulesObj.userAgents['*'].allow;
+
+        userAgentRules.forEach((route) => {
+            let registeredSubPaths = route.split('/').filter(Boolean);
+            let i = 0;
+            routes.some((subPath) => {
+                if (subPath === registeredSubPaths[i]) {
+                    i++;
+                } else {
+                    i = 0;
+                    return true;
+                }
+            });
+
+            if (i > permission) {
+                permission = i;
+            }
+        });
+    }
+
+    return permission;
+};
+
 robotto.check = function(userAgent, urlParam, rulesObj) {
     let userAgents = Object.keys(rulesObj.userAgents);
     let rules = rulesObj.userAgents;
@@ -97,7 +157,7 @@ robotto.check = function(userAgent, urlParam, rulesObj) {
                 if (desiredRoute === route.split('/')[1]) {
                     allowed = false;
                     return true;
-                  } else if (route === '/') {
+                } else if (route === '/') {
                     allowed = false;
                     return true;
                 }

--- a/test/robotto.test.js
+++ b/test/robotto.test.js
@@ -138,8 +138,101 @@ describe('robotto', () => {
         });
     });
 
+    describe('getAllowDeepness', () => {
+        it('should return the correct deepness for a specified route', () => {
+            let rules = {
+                comments: ['comment 1'],
+                userAgents: {
+                    '007': {
+                        allow: [],
+                        disallow: ['/']
+                    },
+                    '*': {
+                        allow: ['/first/second/'],
+                        disallow: ['/']
+                    }
+                }
+            };
+
+            let permission = robotto.getAllowDeepness('UnknownAgent', '/first/second/', rules);
+            assert.strictEqual(permission, 2);
+        });
+
+        it('should return the correct deepness for a specified route and user-agent', () => {
+            let rules = {
+                comments: ['comment 1'],
+                userAgents: {
+                    '007': {
+                        allow: ['/one/two/three/'],
+                        disallow: ['/']
+                    },
+                    '*': {
+                        allow: ['/first/second/'],
+                        disallow: ['/']
+                    }
+                }
+            };
+
+            let permission = robotto.getAllowDeepness('007', '/one/two/three/', rules);
+            assert.strictEqual(permission, 3);
+        });
+
+        it('should return 0 for a non-specified route', () => {
+            let rules = {
+                comments: ['comment 1'],
+                userAgents: {
+                    '007': {
+                        allow: ['/one/two/three/'],
+                        disallow: ['/']
+                    },
+                    '*': {
+                        allow: ['/first/second/'],
+                        disallow: ['/']
+                    }
+                }
+            };
+
+            let permission = robotto.getAllowDeepness('007', '/does/not/exist/', rules);
+            assert.strictEqual(permission, 0);
+        });
+
+        it('should return 0 for an incomplete match using a specified user-agent', () => {
+            let rules = {
+                comments: ['comment 1'],
+                userAgents: {
+                    '007': {
+                        allow: ['/one/two/three/'],
+                        disallow: ['/']
+                    },
+                    '*': {
+                        allow: ['/first/second/'],
+                        disallow: ['/']
+                    }
+                }
+            };
+
+            let permission = robotto.getAllowDeepness('007', '/one/two/four/', rules);
+            assert.strictEqual(permission, 0);
+        });
+
+        it('should return 0 when using unknown user-agent and there are no general rules', () => {
+            let rules = {
+                comments: ['comment 1'],
+                userAgents: {
+                    '007': {
+                        allow: ['/one/two/three/'],
+                        disallow: ['/']
+                    }
+                }
+            };
+
+            let permission = robotto.getAllowDeepness('UnknownAgent', '/one/two/three/', rules);
+            assert.strictEqual(permission, 0);
+        });
+    });
+
     describe('check', () => {
-        it('should find a disallowed route for a specified agent', () => {
+        it('should find a dgetAllowDeepness route for a specified agent', () => {
             let permission1 = robotto.check('007', 'http://secrets.com/admin/login', fake.rules());
             let permission2 = robotto.check('007', 'http://secrets.com/admin', fake.rules());
 
@@ -155,7 +248,7 @@ describe('robotto', () => {
             assert.strictEqual(permission2, true);
         });
 
-        it('should find a disallowed route for a non-specified agent', () => {
+        it('should find a dgetAllowDeepness route for a non-specified agent', () => {
             let permission1 = robotto.check('NotKnownSpy', 'http://secrets.com/spies/daniel-craig', fake.rules());
             let permission2 = robotto.check('NotKnownSpy', 'http://secrets.com/spies', fake.rules());
 
@@ -163,7 +256,7 @@ describe('robotto', () => {
             assert.strictEqual(permission2, false);
         });
 
-        it('should know every route is disallowed for a specified user agent', () => {
+        it('should know every route is dgetAllowDeepness for a specified user agent', () => {
             let rules = {
                 comments: ['comment 1'],
                 userAgents: {
@@ -178,7 +271,7 @@ describe('robotto', () => {
             assert.strictEqual(permission, false);
         });
 
-        it('should know every route is disallowed for a non-specified user agent', () => {
+        it('should know every route is dgetAllowDeepness for a non-specified user agent', () => {
             let rules = {
                 comments: ['comment 1'],
                 userAgents: {
@@ -197,7 +290,7 @@ describe('robotto', () => {
             assert.strictEqual(permission, false);
         });
 
-        it('should not match partial disallowed urls for specified user-agent', () => {
+        it('should not match partial dgetAllowDeepness urls for specified user-agent', () => {
             let rules = {
                 comments: ['comment 1'],
                 userAgents: {
@@ -216,7 +309,7 @@ describe('robotto', () => {
             assert.strictEqual(permission, true);
         });
 
-        it('should not match partial disallowed urls for a non-specified user-agent', () => {
+        it('should not match partial dgetAllowDeepness urls for a non-specified user-agent', () => {
             let rules = {
                 comments: ['comment 1'],
                 userAgents: {


### PR DESCRIPTION
@vieiralucas 
I was thinking about creating a single getPermissionDeepness method.
It would be something like:

``` js
robotto.getPermissionDeepness(allowOrNot, userAgent, route, rulesObj) {
  if (allowOrNot !== "allow" && allowOrNot !== "disallow") {
    return -1;
  }

  // Here I would change every reference to .allow to [allowOrNot]
  // This means we would have a single method both for allow and disallow rules
}
```

The option above avoids code repetition, but adds complexity and thrust into the user.
What do you think?
