### PR TITLE
Remove unnecessary ternary operator on check method

### DIFF
--- a/src/robotto.js
+++ b/src/robotto.js
@@ -146,7 +146,7 @@ robotto.check = function(userAgent, urlParam, rulesObj) {
     // Negative if disallow rule is more specific
     let finalPermissionLevel = allowLevel - disallowLevel;
 
-    return (finalPermissionLevel >= 0) ? true : false;
+    return finalPermissionLevel >= 0;
 };
 
 robotto.canCrawl = function(userAgent, urlParam, callback) {


### PR DESCRIPTION
This code was like...
If true then true, otherwise false.

MADNESS
