### PR TITLE
Fix overriding rules when an user-agent gets repeated. Closes #75.

### DIFF
--- a/src/robotto.js
+++ b/src/robotto.js
@@ -58,10 +58,12 @@ robotto.parse = function(robotsFile) {
         let userAgentIndex = line.toLowerCase().indexOf('user-agent:');
         if (userAgentIndex === 0) {
             lastUserAgent = line.split(':')[1].trim();
-            rulesObj.userAgents[lastUserAgent] = {
-                allow: [],
-                disallow: []
-            };
+            if (rulesObj.userAgents[lastUserAgent] === undefined) {
+                rulesObj.userAgents[lastUserAgent] = {
+                    allow: [],
+                    disallow: []
+                };
+            }
             return;
         }
 

--- a/test/robotto.test.js
+++ b/test/robotto.test.js
@@ -167,6 +167,29 @@ describe('robotto', () => {
         it('should actually parse a robots.txt file', () => {
             assert.deepEqual(robotto.parse(fake.robots()), fake.rules());
         });
+
+        it('should add repeated user agent rules to the same user agent as before', () => {
+            let robotsFile = [
+                'User-agent: *',
+                'Disallow: /first/',
+                'User-agent: *',
+                'Disallow: /middle/',
+                'User-agent: *',
+                'Disallow: /last/',
+            ].join('\n');
+
+            let expectedRules = {
+                comments: [],
+                userAgents: {
+                    '*': {
+                        allow: [],
+                        disallow: ['/first/', '/middle/', '/last/']
+                    }
+                }
+            }
+
+            assert.deepEqual(robotto.parse(robotsFile), expectedRules);
+        });
     });
 
     describe('getRuleDeepness', () => {


### PR DESCRIPTION
When we had repeating user agents their rules would be overwritten because we were not prepared to handle specific rules for user agents that were already defined before.

This basically adds a check to see if that user agent already had any rules before creating an empty object to hold its rules.

I also added tests for that.

PS.: We did this a long time ago and we've gotten better at JavaScript in general, would you like to tackle a massive refactor with me @vieiralucas?