### PR TITLE
Set maxRedirects to 5 for fetch

### DIFF
--- a/src/robotto.js
+++ b/src/robotto.js
@@ -13,9 +13,13 @@ robotto.getRobotsUrl = function(urlP) {
 robotto.fetch = function(urlP, callback) {
     callback = typeof callback === 'function' ? callback : new Function();
 
-    let robotsUrl = this.getRobotsUrl(urlP);
+    const requestOptions = {
+        url: this.getRobotsUrl(urlP),
+        maxRedirects: 5
+    };
 
-    request.get(robotsUrl, (err, res, body) => {
+
+    request.get(requestOptions, (err, res, body) => {
         if (err) {
             callback(err);
             return;

--- a/test/robotto.test.js
+++ b/test/robotto.test.js
@@ -44,7 +44,7 @@ describe('robotto', () => {
 
         it('should call request.get', (done) => {
             robotto.fetch(coolUrl, () => {
-                sinon.assert.calledWith(request.get, coolRobot);
+                sinon.assert.calledWith(request.get, { url: coolRobot, maxRedirects: 5 });
                 done();
             });
         });


### PR DESCRIPTION
Closes #80 
We should set a maxRedirect to avoid `Warning: Possible EventEmitter memory leak detected.`

[RFC 1945](https://www.ietf.org/rfc/rfc1945.txt) specifies `5` as the maximum.
> 9.3  Redirection 3xx
>
>   This class of status code indicates that further action needs to be
>   taken by the user agent in order to fulfill the request. The action
>   required may be carried out by the user agent without interaction
>   with the user if and only if the method used in the subsequent
>   request is GET or HEAD. **A user agent should never automatically
>   redirect a request more than 5 times**, since such redirections usually
>   indicate an infinite loop.
